### PR TITLE
Save only printable UTF-8 characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "voku/portable-utf8": "^3.1"
     },
     "suggest": {
 		"doctrine/mongodb": "For using with MongoDB",

--- a/src/Devture/Component/DBAL/Model/BaseModel.php
+++ b/src/Devture/Component/DBAL/Model/BaseModel.php
@@ -14,6 +14,10 @@ abstract class BaseModel {
 	}
 
 	protected function setAttribute($key, $value) {
+		if(is_string($value)) {
+			$value = \voku\helper\UTF8::cleanup($value);
+		}
+		
 		$this->record[$key] = $value;
 	}
 


### PR DESCRIPTION
 - use 'voku/portable-utf8' for the string cleanup
 - ignore 'vendor' directory and 'composer.lock' file